### PR TITLE
IPv4アドレス要件をREADMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 - EC2インスタンスは作成済み
 - EC2にSSHで接続できる
 - EC2でgit cloneできるようSSH鍵をgithubに設定済み
+- EC2インスタンスに一時的にIPv4アドレス付与済み
+  - composer installコマンドでGitHubからcloneするためIPv4が必要です
+  - EC2構築時にはIPv4を付与しないようになっているため、Ansible実行前に一時的に付与してください
+  - 作業完了後、IPv4アドレスは解除できます
 
 ## 事前準備
 


### PR DESCRIPTION
## 概要
READMEの前提欄に、Ansible実行前にEC2に一時的にIPv4アドレスを付与する必要がある旨を追記しました。

## 変更内容
- composer installコマンドでGitHubからcloneするためにIPv4が必要であることを明記
- EC2構築時にはIPv4を付与しないようになっているため、一時的な付与が必要であることを説明
- 作業完了後にIPv4アドレスを解除できることを追記

Close #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)